### PR TITLE
Add import statements to hello-cpp/hello/__init__.py

### DIFF
--- a/projects/hello-cpp/hello/__init__.py
+++ b/projects/hello-cpp/hello/__init__.py
@@ -1,0 +1,2 @@
+from ._hello import hello
+from ._hello import elevation

--- a/projects/hello-cpp/hello/_hello.cxx
+++ b/projects/hello-cpp/hello/_hello.cxx
@@ -14,7 +14,7 @@ static PyObject *hello_example(PyObject *self, PyObject *args)
     return NULL;
 
   // Print message and return None
-  PySys_WriteStdout("Hello, %s!)\n", strArg);
+  PySys_WriteStdout("Hello, %s!\n", strArg);
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
I updated `__init__.py` in hello-cpp to explicitly import the functions `hello` and `elevation` from the `_hello` shared library, as the existing version wasn't working for me in my environment (Centos).