### PR TITLE
add _hello imports to __init__.py

### DIFF
--- a/projects/hello-cython/hello/__init__.py
+++ b/projects/hello-cython/hello/__init__.py
@@ -1,0 +1,1 @@
+from ._hello import hello, elevation


### PR DESCRIPTION
This folder has the same problem as #5 in that the `pip install .` appears to do nothing.
To make it more apparent that the install is working, this import statement now allows access
to `hello.elevation()` and `hello.hello(...)` when you run `import hello` after installing