### PR TITLE
chore: update versions

### DIFF
--- a/projects/hello-pybind11/CMakeLists.txt
+++ b/projects/hello-pybind11/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.6.0
+  GIT_TAG v2.6.2
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/projects/hello-pybind11/CMakeLists.txt
+++ b/projects/hello-pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.17)
+cmake_minimum_required(VERSION 3.14...3.18)
 
 project(hello-pybind11 VERSION "0.1")
 
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.5.0
+  GIT_TAG v2.6.0
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
Small update for the pybind11 example. Another way to do it could be to use the pip module, but it's hard to get Scikit-Build to find the CMake files in that case on all platforms. Adding site-packages to the search path would do it.