### PR TITLE
chore: bump versions to 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
     - master
+
+env:
+  FORCE_COLOR: 3
 
 jobs:
   checks:
@@ -19,5 +23,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: excitedleigh/setup-nox@v2.0.0
-
-    - run: nox --force-color
+    - run: nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,35 +1,24 @@
 import nox
-from pathlib import Path
-import shutil
 
 hello_list = "hello-pure", "hello-cpp", "hello-pybind11", "hello-cython"
+long_hello_list = hello_list + ("pen2-cython",)
 
 
 @nox.session
-@nox.parametrize("module", hello_list + ("pen2-cython",))
-def dist(session, module):
+@nox.parametrize("module", long_hello_list, ids=long_hello_list)
+def dist(session: nox.Session, module: str) -> None:
     session.cd(f"projects/{module}")
     session.install("build")
-
-    # Cleanup bad caching
-    skbuild = Path("_skbuild")
-    if skbuild.exists():
-        shutil.rmtree(skbuild)
 
     # Builds SDist and wheel
     session.run("pyproject-build")
 
 
 @nox.session
-@nox.parametrize("module", hello_list)
-def test(session, module):
+@nox.parametrize("module", hello_list, ids=hello_list)
+def test(session: nox.Session, module: str) -> None:
     session.cd(f"projects/{module}")
     session.install("pytest", "pytest-cov")
-
-    # Cleanup bad caching
-    skbuild = Path("_skbuild")
-    if skbuild.exists():
-        shutil.rmtree(skbuild)
 
     session.install(".")
     session.run("pytest")

--- a/projects/hello-cpp/CMakeLists.txt
+++ b/projects/hello-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.4...3.22)
 
 project(hello)
 

--- a/projects/hello-cpp/pyproject.toml
+++ b/projects/hello-cpp/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build>=0.13",
     "cmake>=3.18",
     "ninja",
 ]

--- a/projects/hello-cpp/setup.py
+++ b/projects/hello-cpp/setup.py
@@ -1,13 +1,4 @@
-import sys
-
 from skbuild import setup
-
-# Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
-                 if any(arg in sys.argv for arg in ('pytest', 'test'))
-                 else [])
-
-setup_requires = pytest_runner
 
 setup(
     name="hello-cpp",
@@ -16,6 +7,5 @@ setup(
     author='The scikit-build team',
     license="MIT",
     packages=['hello'],
-    tests_require=['pytest'],
-    setup_requires=setup_requires
+    python_requires=">=3.7",
 )

--- a/projects/hello-cython/CMakeLists.txt
+++ b/projects/hello-cython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.5...3.22)
 
 project(hello_cython)
 

--- a/projects/hello-cython/pyproject.toml
+++ b/projects/hello-cython/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build>=0.13",
     "cmake>=3.18",
     "ninja",
     "cython",

--- a/projects/hello-cython/setup.py
+++ b/projects/hello-cython/setup.py
@@ -1,13 +1,5 @@
-import sys
-
 from skbuild import setup
 
-# Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
-                 if any(arg in sys.argv for arg in ('pytest', 'test'))
-                 else [])
-
-setup_requires = pytest_runner
 
 setup(
     name="hello-cython",
@@ -16,7 +8,5 @@ setup(
     author='The scikit-build team',
     license="MIT",
     packages=['hello'],
-    install_requires=['cython'],
-    tests_require=['pytest'],
-    setup_requires=setup_requires
+    python_requires=">=3.7",
 )

--- a/projects/hello-pure/pyproject.toml
+++ b/projects/hello-pure/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build>=0.13",
     "cmake>=3.18",
     "ninja",
 ]

--- a/projects/hello-pure/setup.py
+++ b/projects/hello-pure/setup.py
@@ -1,13 +1,5 @@
-import sys
-
 from skbuild import setup
 
-# Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
-                 if any(arg in sys.argv for arg in ('pytest', 'test'))
-                 else [])
-
-setup_requires = pytest_runner
 
 setup(
     name="hello-pure",
@@ -16,6 +8,5 @@ setup(
     author='The scikit-build team',
     license="MIT",
     packages=['hello'],
-    tests_require=['pytest'],
-    setup_requires=setup_requires
+    python_requires=">=3.7",
 )

--- a/projects/hello-pybind11/CMakeLists.txt
+++ b/projects/hello-pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.18)
+cmake_minimum_required(VERSION 3.14...3.22)
 
 project(hello-pybind11 VERSION "0.1")
 
@@ -10,8 +10,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.6.2.tar.gz
-  URL_HASH SHA256=8ff2fff22df038f5cd02cea8af56622bc67f5b64534f1b83b9f133b8366acff2
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.9.1.tar.gz
+  URL_HASH SHA256=c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/projects/hello-pybind11/pyproject.toml
+++ b/projects/hello-pybind11/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build>=0.13",
     "cmake",
     "ninja",
 ]

--- a/projects/hello-pybind11/setup.py
+++ b/projects/hello-pybind11/setup.py
@@ -1,11 +1,4 @@
-import sys
-
-try:
-    from skbuild import setup
-except ImportError:
-    print('Please update pip, you need pip 10 or greater,\n'
-          ' or you need to install the PEP 518 requirements in pyproject.toml yourself', file=sys.stderr)
-    raise
+from skbuild import setup
 
 setup(
     name="hello-pybind11",
@@ -15,5 +8,6 @@ setup(
     license="MIT",
     packages=['hello'],
     package_dir={'': 'src'},
-    cmake_install_dir='src/hello'
+    cmake_install_dir='src/hello',
+    python_requires='>=3.7',
 )

--- a/projects/pen2-cython/CMakeLists.txt
+++ b/projects/pen2-cython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.5...3.22)
 
 project(pen2_cython)
 

--- a/projects/pen2-cython/pyproject.toml
+++ b/projects/pen2-cython/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "scikit-build>=0.12",
+    "scikit-build>=0.13",
     "cmake>=3.18",
     "ninja",
     "cython",

--- a/projects/pen2-cython/setup.py
+++ b/projects/pen2-cython/setup.py
@@ -11,5 +11,6 @@ setup(
     package_dir={
         'pen2_cython': 'src'
     },
-    scripts=['scripts/pen2_cython']
+    scripts=['scripts/pen2_cython'],
+    python_requires='>=3.7',
 )

--- a/projects/tower-of-babel/CMakeLists.txt
+++ b/projects/tower-of-babel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.5...3.22)
 
 project(tower_of_babel)
 

--- a/projects/tower-of-babel/setup.py
+++ b/projects/tower-of-babel/setup.py
@@ -7,6 +7,6 @@ setup(
                 "module types and code generation technologies",
     author="The scikit-build team",
     license="MIT",
-
     scripts=['scripts/tbabel'],
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Updating versions (mostly scikit-build to 0.13), and minor cleanup:

* You can run the CI manually without making a PR (say after a scikit-build release)
* Removed `_skbuild` caching workaround (not needed anymore, I believe)
* Upper limit of 3.22 for CMake min required
* Removed pytest-runner, tests_require and custom test command (in fact all commands) are deprecated in setuptools and produce warnings
* Removed setup_requires, long deprecated and now produces warnings
* Set python_requires to 3.7+. Not actually the minimum for the little bit of code we have, but no need to include EOL Pythons in examples.
* Bumped pybind11 to 2.9.1