### PR TITLE
Add core cython hello

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ hello_list = [
     "hello-cpp",
     "hello-pybind11",
     "hello-cython",
+    "core-cython-hello",
     "hello-cmake-package",
     "pi-fortran",
 ]

--- a/projects/core-cython-hello/CMakeLists.txt
+++ b/projects/core-cython-hello/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15...3.26)
+
+project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES C)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+
+find_package(Cython MODULE REQUIRED VERSION 3.0)
+include(UseCython)
+
+add_subdirectory(hello)

--- a/projects/core-cython-hello/hello/CMakeLists.txt
+++ b/projects/core-cython-hello/hello/CMakeLists.txt
@@ -1,0 +1,5 @@
+cython_transpile(_hello.pyx LANGUAGE C OUTPUT_VARIABLE _hello_c)
+
+python_add_library(_hello MODULE "${_hello_c}" WITH_SOABI)
+
+install(TARGETS _hello LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/projects/core-cython-hello/hello/__init__.py
+++ b/projects/core-cython-hello/hello/__init__.py
@@ -1,0 +1,3 @@
+from ._hello import elevation, hello
+
+__all__ = ("elevation", "hello")

--- a/projects/core-cython-hello/hello/_hello.pyx
+++ b/projects/core-cython-hello/hello/_hello.pyx
@@ -1,0 +1,8 @@
+
+cpdef void hello(str strArg):
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+    print("Hello, {}!".format(strArg))
+
+cpdef long elevation():
+    "Returns elevation of Nevado Sajama."
+    return 21463

--- a/projects/core-cython-hello/pyproject.toml
+++ b/projects/core-cython-hello/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["scikit-build-core", "cython>=3.0", "cython-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "hello"
+version = "1.2.3"
+authors = [
+  { name = "The scikit-build team" },
+]
+description = "a minimal example package (cython version)"
+requires-python = ">=3.9"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+]
+dependencies = []
+
+[tool.scikit-build]
+cmake.source-dir = "."
+minimum-version = "0.5"

--- a/projects/core-cython-hello/tests/test_hello_cython.py
+++ b/projects/core-cython-hello/tests/test_hello_cython.py
@@ -1,0 +1,11 @@
+import hello
+
+
+def test_hello(capfd):
+    hello.hello("World")
+    captured = capfd.readouterr()
+    assert captured.out == "Hello, World!\n"
+
+
+def test_elevation():
+    assert hello.elevation() == 21463


### PR DESCRIPTION
Once finalized, this pull request will add the `core-cython-hello` sample project demonstrating how to leverage `scikit-build-core` and `cython`.

In the meantime, it is used as a "maturing" ground to consolidate the changes originally developed by @vyasr in the context of https://github.com/rapidsai/rapids-cmake/pull/433


Related issues:
* https://github.com/scikit-build/scikit-build-core/issues/442
* https://github.com/cython/cython/issues/5486
* https://gitlab.kitware.com/cmake/cmake/-/issues/24982
* https://github.com/rapidsai/rapids-cmake/pull/433
