### PR TITLE
ci: use uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,14 @@ jobs:
     name: Check on ${{ matrix.runs-on }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: awvwgk/setup-fortran@main
       id: setup-fortran
       with:
         compiler: gcc
         version: 11
-    - uses: wntrblm/nox@2022.11.21
+    - uses: yezz123/setup-uv@v4
+    - uses: wntrblm/nox@2024.04.15
     - run: nox
 
   pass:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,21 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        session: [dist, test]
 
-    name: Check on ${{ matrix.runs-on }}
+    name: ${{ matrix.session }} on ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
     - uses: awvwgk/setup-fortran@main
       id: setup-fortran
+      if: runner.os != 'Windows'  # We aren't using this yet, and takes 4 mins to setup
       with:
         compiler: gcc
         version: 11
     - uses: yezz123/setup-uv@v4
     - uses: wntrblm/nox@2024.04.15
-    - run: nox
+    - run: nox -s ${{ matrix.session }}
 
   pass:
     if: always()

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,9 @@ import sys
 
 import nox
 
+nox.needs_version = ">=2024.4.15"
+nox.options.default_venv_backend = "uv|virtualenv"
+
 hello_list = ["hello-pure", "hello-cpp", "hello-pybind11", "hello-cython"]
 if not sys.platform.startswith("win"):
     hello_list.extend(["hello-cmake-package", "pi-fortran"])
@@ -15,7 +18,8 @@ def dist(session: nox.Session, module: str) -> None:
     session.install("build")
 
     # Builds SDist and wheel
-    session.run("python", "-m", "build")
+    opt = ["--installer=uv"] if session.venv_backend == "uv" else []
+    session.run("python", "-m", "build", *opt)
 
 
 @nox.session


### PR DESCRIPTION
Makes it quite a bit faster locally, let's see if we can get under 3/11/11 mins. :)

* Ubuntu dropped from 2:52 to 1:37 mins.
* macOS dropped from 10:15 to 2:38 mins.
* Windows dropped from 10:29 to 8:26 mins. (Over 4 mins is in setup-fortran, which we don't use, so disabling it after the benchmark comparison)

Also split up jobs into two parts. Final result: CI takes about 2 mins, instead of 11. :)