### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, windows-latest]
+        runs-on: [ubuntu-latest, macos-12, windows-latest]
         session: [dist, test]
 
     name: ${{ matrix.session }} on ${{ matrix.runs-on }}
@@ -32,7 +32,7 @@ jobs:
       id: setup-fortran
       if: runner.os != 'Windows'
       # We aren't using this yet, and takes 4 mins to setup on Windows
-      # On macOS this causes abut to be hit on macos-13+ and CMake
+      # On macOS this causes a bug to be hit on macos-13+ and CMake, gcc14 may fix
       with:
         compiler: gcc
         version: 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       # On macOS this causes abut to be hit on macos-13+ and CMake
       with:
         compiler: gcc
-        version: 14
+        version: 12
     - uses: yezz123/setup-uv@v4
     - uses: wntrblm/nox@2024.04.15
     - run: nox -s ${{ matrix.session }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
     - uses: actions/checkout@v4
     - uses: awvwgk/setup-fortran@main
       id: setup-fortran
-      if: runner.os == 'Linux'
+      if: runner.os != 'Windows'
       # We aren't using this yet, and takes 4 mins to setup on Windows
       # On macOS this causes abut to be hit on macos-13+ and CMake
       with:
         compiler: gcc
-        version: 11
+        version: 14
     - uses: yezz123/setup-uv@v4
     - uses: wntrblm/nox@2024.04.15
     - run: nox -s ${{ matrix.session }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: awvwgk/setup-fortran@main
       id: setup-fortran
-      if: runner.os != 'Windows'  # We aren't using this yet, and takes 4 mins to setup
+      if: runner.os == 'Linux'
+      # We aren't using this yet, and takes 4 mins to setup on Windows
+      # On macOS this causes abut to be hit on macos-13+ and CMake
       with:
         compiler: gcc
         version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
         session: [dist, test]
 
     name: ${{ matrix.session }} on ${{ matrix.runs-on }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos