### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         compiler: gcc
         version: 12
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@v8.0.0
     - run: uvx nox -s ${{ matrix.session }}
 
   free-threading:
@@ -50,7 +50,7 @@ jobs:
     name: cibw on ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@v8.0.0
     - uses: pypa/cibuildwheel@v2.21
       with:
           package-dir: projects/hello-free-threading


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos