### PR TITLE
fix: declare editable.mode for hello-cmake-package

### DIFF
--- a/projects/hello-cmake-package/pyproject.toml
+++ b/projects/hello-cmake-package/pyproject.toml
@@ -7,3 +7,6 @@ requires = [
     "pybind11>=2.12"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.scikit-build]
+editable.mode = 'inplace'


### PR DESCRIPTION
Fun fact: this was generated by Claude Fable 5 - while working on a different PR: https://github.com/scikit-build/scikit-build/pull/1185.

:robot: _AI text below_ :robot:

The next major scikit-build release replaces its backend with scikit-build-core's setuptools plugin (see scikit-build/scikit-build-core#1316; scikit-build draft PR to follow). Editable/inplace installs there require `editable.mode = "inplace"` under `[tool.scikit-build]`, so this adds that to hello-cmake-package's pyproject.toml.

No other changes needed: all six classic-skbuild sample projects (hello-cpp, hello-pure, hello-cython, hello-pybind11, pen2-cython, hello-cmake-package) build unchanged against the new backend, and scikit-build's CI now builds them on Linux/macOS/Windows as a regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)