### PR TITLE
ci: update CI runner images (macos-14, pin Windows to VS2022)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-14, windows-latest]
+        # Pin Windows to 2022 (VS2022); windows-latest moved to VS2026,
+        # which classic scikit-build does not yet support.
+        runs-on: [ubuntu-latest, macos-14, windows-2022]
         session: [dist, test]
 
     name: ${{ matrix.session }} on ${{ matrix.runs-on }}
@@ -44,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, windows-latest, macos-14]
+        runs-on: [ubuntu-latest, windows-2022, macos-14]
     name: cibw on ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, windows-latest]
+        runs-on: [ubuntu-latest, macos-14, windows-latest]
         session: [dist, test]
 
     name: ${{ matrix.session }} on ${{ matrix.runs-on }}
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        runs-on: [ubuntu-latest, windows-latest, macos-14]
     name: cibw on ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, windows-2022, macos-14]
+        runs-on: [ubuntu-latest, windows-latest, macos-14]
     name: cibw on ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Keeps CI green as GitHub rolls runner images forward.

- **macos-13 → macos-14**: the Intel `macos-13` runner is being retired. `checks` matrix updated; `free-threading` drops `macos-13` (`macos-14` was already present, so no coverage lost).
- **windows-latest → windows-2022** (`checks` job only): `windows-latest` now resolves to `windows-2025` with Visual Studio 2026, which classic scikit-build does not yet support. Pinned to `windows-2022` (VS2022) as a temporary measure until scikit-build (classic) supports VS2026. The `free-threading` job builds with scikit-build-core (unaffected) and stays on `windows-latest`.

## Test plan
- CI config change; the updated matrices run on this PR.