### PR TITLE
fix(hello-cmake-package): build and run on Windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,9 +5,15 @@ import nox
 nox.needs_version = ">=2024.4.15"
 nox.options.default_venv_backend = "uv|virtualenv"
 
-hello_list = ["hello-pure", "hello-cpp", "hello-pybind11", "hello-cython"]
+hello_list = [
+    "hello-pure",
+    "hello-cpp",
+    "hello-pybind11",
+    "hello-cython",
+    "hello-cmake-package",
+]
 if not sys.platform.startswith("win"):
-    hello_list.extend(["hello-cmake-package", "pi-fortran"])
+    hello_list.append("pi-fortran")
 long_hello_list = [
     *hello_list,
     "pen2-cython",

--- a/projects/hello-cmake-package/CMakeLists.txt
+++ b/projects/hello-cmake-package/CMakeLists.txt
@@ -10,6 +10,12 @@ include(GNUInstallDirs)
 # define the C++ library "hello"
 add_library(hello SHARED "${PROJECT_SOURCE_DIR}/src/hello.cpp")
 
+# On Windows, MSVC only emits an import library (hello.lib) when symbols are
+# exported. Without it, linking _hello against this SHARED target fails with
+# LNK1181. Export all symbols so the project builds cross-platform without
+# annotating the source with __declspec(dllexport).
+set_target_properties(hello PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 target_include_directories(
   hello PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/projects/hello-cmake-package/CMakeLists.txt
+++ b/projects/hello-cmake-package/CMakeLists.txt
@@ -29,10 +29,16 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
 #
 # Installing the objects in the package provides encapsulation and will become
 # important later for binary redistribution reasons.
+# RUNTIME/ARCHIVE destinations are needed on Windows: the .dll is a RUNTIME
+# artifact and the import .lib is an ARCHIVE artifact, so a LIBRARY-only
+# destination would install neither. Keeping them all in LIBDIR mirrors the
+# Unix layout (everything under "<package>/lib/").
 install(
   TARGETS hello
   EXPORT helloTargets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # The CMake package config and target files are installed under the Python
 # package root. This is necessary to ensure that all the relative paths in the

--- a/projects/hello-cmake-package/src/hello/__init__.py
+++ b/projects/hello-cmake-package/src/hello/__init__.py
@@ -1,3 +1,12 @@
+import os
+import sys
+from pathlib import Path
+
+# Windows ignores RPATH, so the relative path baked into _hello cannot locate
+# hello.dll in the lib/ subdirectory. Register it as a DLL search directory.
+if sys.platform == "win32":
+    os.add_dll_directory(str(Path(__file__).parent / "lib"))
+
 from ._hello import hello, return_two
 
 __all__ = ("hello", "return_two")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fixes #67. `hello-cmake-package` was excluded from Windows in `noxfile.py` because it could neither build nor import there. This makes it work cross-platform and drops the exclusion (`pi-fortran` stays Windows-excluded for its Fortran toolchain).

Three Windows-specific problems, surfacing one after the other:

1. **Linking failed (`LNK1181`).** The `hello` library is `SHARED` but exported no symbols, so MSVC produced `hello.dll` but no import library (`hello.lib`), and linking `_hello` failed.
2. **DLL was never packaged.** `install(TARGETS hello LIBRARY DESTINATION ...)` only installs the LIBRARY-kind artifact. On Windows the `.dll` is a RUNTIME artifact and the import `.lib` is ARCHIVE, so neither shipped in the wheel.
3. **DLL not found at import (`DLL load failed`).** Windows ignores RPATH, so the relative `$ORIGIN/lib` path baked into `_hello` could not locate `hello.dll`.

## Changes

- **`CMakeLists.txt`**:
  - `WINDOWS_EXPORT_ALL_SYMBOLS ON` on `hello` so an import library is produced. No effect on non-Windows platforms.
  - Add `RUNTIME`/`ARCHIVE` destinations to the `install(TARGETS)` (kept in `LIBDIR` to mirror the Unix layout) so the DLL and import lib ship in the wheel.
- **`src/hello/__init__.py`**: on Windows, register the `lib/` directory via `os.add_dll_directory` before importing `_hello`.
- **`noxfile.py`**: add `hello-cmake-package` to `hello_list` unconditionally.

## Testing

`uvx nox -s "test(hello-cmake-package)"` passes locally on macOS. CI is green across `test`/`dist`/`cibw` on ubuntu / macos / windows.