### PR TITLE
ci: require scikit-build>=0.19.1 for MSVC 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Pin Windows to 2022 (VS2022); windows-latest moved to VS2026,
-        # which classic scikit-build does not yet support.
-        runs-on: [ubuntu-latest, macos-14, windows-2022]
+        runs-on: [ubuntu-latest, macos-14, windows-latest]
         session: [dist, test]
 
     name: ${{ matrix.session }} on ${{ matrix.runs-on }}

--- a/projects/hello-cmake-package/pyproject.toml
+++ b/projects/hello-cmake-package/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "scikit-build",
+    "scikit-build>=0.19.1",
     "cmake>=3.14",
     "ninja",
     "pybind11>=2.12"

--- a/projects/hello-cpp/pyproject.toml
+++ b/projects/hello-cpp/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "scikit-build>=0.13",
+    "scikit-build>=0.19.1",
     "cmake>=3.18",
     "ninja",
 ]

--- a/projects/hello-cython/pyproject.toml
+++ b/projects/hello-cython/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "scikit-build>=0.13",
+    "scikit-build>=0.19.1",
     "cmake>=3.18",
     "ninja",
     "cython",

--- a/projects/hello-pure/pyproject.toml
+++ b/projects/hello-pure/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "scikit-build>=0.13",
+    "scikit-build>=0.19.1",
     "cmake>=3.18",
     "ninja",
 ]

--- a/projects/hello-pybind11/pyproject.toml
+++ b/projects/hello-pybind11/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "scikit-build>=0.13",
+    "scikit-build>=0.19.1",
     "cmake",
     "ninja",
 ]

--- a/projects/pen2-cython/pyproject.toml
+++ b/projects/pen2-cython/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "scikit-build>=0.13",
+    "scikit-build>=0.19.1",
     "cmake>=3.18",
     "ninja",
     "cython",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

scikit-build 0.19.1 (classic) supports Visual Studio 2026.

- Bump the `scikit-build` floor to `>=0.19.1` in the legacy projects (`hello-pure`, `hello-cpp`, `hello-cython`, `hello-pybind11`, `pen2-cython`, `hello-cmake-package`; the last was previously unpinned).
- Move the `checks` matrix back to `windows-latest` (now VS2026), reverting the earlier `windows-2022` pin that worked around the lack of VS2026 support.

The `free-threading` job already ran on `windows-latest` (cibuildwheel + scikit-build-core, unaffected). `tower-of-babel` is untouched (no pyproject, not in the noxfile lists).