### PR TITLE
chore: bump CMake policy max to 4.4

### DIFF
--- a/projects/core-c-hello/CMakeLists.txt
+++ b/projects/core-c-hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES C)
 

--- a/projects/core-cffi-hello/CMakeLists.txt
+++ b/projects/core-cffi-hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES C)
 

--- a/projects/core-cython-hello/CMakeLists.txt
+++ b/projects/core-cython-hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES C)
 

--- a/projects/core-nanobind-shared/CMakeLists.txt
+++ b/projects/core-nanobind-shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES CXX)
 

--- a/projects/core-pybind11-hello/CMakeLists.txt
+++ b/projects/core-pybind11-hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES CXX)
 

--- a/projects/hatchling-pybind11-hello/CMakeLists.txt
+++ b/projects/hatchling-pybind11-hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(${SKBUILD_PROJECT_NAME} VERSION ${SKBUILD_PROJECT_VERSION} LANGUAGES CXX)
 

--- a/projects/hello-cmake-package/CMakeLists.txt
+++ b/projects/hello-cmake-package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(
   hello

--- a/projects/hello-cmake-package/tests/cpp/CMakeLists.txt
+++ b/projects/hello-cmake-package/tests/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...4.3)
+cmake_minimum_required(VERSION 3.14...4.4)
 
 project(hello-user VERSION 0.1.0)
 

--- a/projects/hello-free-threading/CMakeLists.txt
+++ b/projects/hello-free-threading/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(FreeComputePi LANGUAGES CXX)
 

--- a/projects/hello-pybind11/CMakeLists.txt
+++ b/projects/hello-pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...4.3)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 project(hello-pybind11 VERSION "0.1")
 

--- a/projects/pi-fortran/CMakeLists.txt
+++ b/projects/pi-fortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.2...4.3)
+cmake_minimum_required(VERSION 3.17.2...4.4)
 
 project(pi
   VERSION 1.0.1


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bumps the CMake policy compatibility upper bound from 4.3 to 4.4 in the `cmake_minimum_required(VERSION ...4.4)` line across the scikit-build-core / hatchling / boost projects. The legacy setuptools projects stay at their existing `...3.26` bound.