### PR TITLE
ci(hello-free-threading): target Python 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: astral-sh/setup-uv@v8.0.0
-    - uses: pypa/cibuildwheel@v2.21
+    - uses: pypa/cibuildwheel@v4.1.0
       with:
           package-dir: projects/${{ matrix.package }}
-      env:
-        CIBW_PRERELEASE_PYTHONS: True
 
   pass:
     if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Development is driven by nox (`noxfile.py`). Use `uvx nox` (uv is the assumed ru
 
 `noxfile.py` defines which projects participate, with platform/version gates that must be respected when adding or moving a project:
 
-- `hello_list` (tested by `test`): the four `hello-*` setuptools projects, plus `hello-cmake-package` and `pi-fortran` (**non-Windows only**), plus `core-cffi-hello` (**Python 3.10+ only**, also in `long_hello_list`) and `hello-free-threading` (**Python 3.13+ only**).
+- `hello_list` (tested by `test`): the four `hello-*` setuptools projects, plus `hello-cmake-package` and `pi-fortran` (**non-Windows only**), plus `core-cffi-hello` (**Python 3.10+ only**, also in `long_hello_list`) and `hello-free-threading` (**Python 3.14+ only**).
 - `long_hello_list` (built by `dist`): `hello_list` plus `pen2-cython`, `core-c-hello`, `core-pybind11-hello`, `hatchling-pybind11-hello`.
 - `hello-free-threading` and `core-nanobind-shared` are also wheel-built and tested via cibuildwheel in CI (`cibuildwheel` job); `hello-free-threading` only through that job, not nox.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ configured via `[tool.scikit-build]`.
 | [`core-pybind11-hello`](projects/core-pybind11-hello) | pybind11 binding |
 | [`core-nanobind-shared`](projects/core-nanobind-shared) | [nanobind](https://nanobind.readthedocs.io) binding linking a shared library shipped in the wheel |
 | [`hello-cmake-package`](projects/hello-cmake-package) | Standalone C library, exported CMake package, and pybind11 wrapper |
-| [`hello-free-threading`](projects/hello-free-threading) | Free-threaded (no-GIL) build; requires Python 3.13+ |
+| [`hello-free-threading`](projects/hello-free-threading) | Free-threaded (no-GIL) build; requires Python 3.14+ |
 | [`pi-fortran`](projects/pi-fortran) | Fortran via f2py and [f2py-cmake](https://github.com/scikit-build/f2py-cmake) |
 
 ### Hatchling + scikit-build-core plugin

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ if sys.version_info >= (3, 10):
     # cffi 2.1 (first release with cffi-gen-src) requires Python 3.10
     hello_list.append("core-cffi-hello")
     long_hello_list.append("core-cffi-hello")
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
     hello_list.append("hello-free-threading")
 
 

--- a/projects/core-nanobind-shared/pyproject.toml
+++ b/projects/core-nanobind-shared/pyproject.toml
@@ -15,10 +15,15 @@ classifiers = [
 ]
 
 # One version is enough here; the point is exercising the wheel-repair step
-# (auditwheel/delocate) over the shipped shared library.
+# (auditwheel/delocate/delvewheel) over the shipped shared library.
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build = "cp312-*"
 archs = ["auto64"]
 test-command = "pytest {package}"
 test-requires = ["pytest"]
+
+# say_hello.dll is installed next to the .pyd, so delvewheel (default on
+# Windows since cibuildwheel 4.0) must not try to locate and re-vendor it.
+[tool.cibuildwheel.windows]
+repair-wheel-command = "delvewheel repair --ignore-existing -w {dest_dir} {wheel}"

--- a/projects/hello-free-threading/pyproject.toml
+++ b/projects/hello-free-threading/pyproject.toml
@@ -5,11 +5,10 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "freecomputepi"
 version = "0.0.1"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-build = "cp313*"
-free-threaded-support = true
+build = "cp314*"
 test-command = "pytest {package} --durations=0"
 test-requires = ["pytest"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Switch the `hello-free-threading` sample from 3.13t to 3.14t.

Free-threaded CPython 3.14+ builds with cibuildwheel without an enable flag (see cibuildwheel v4.0.0 changelog), so this drops `free-threaded-support` and `CIBW_PRERELEASE_PYTHONS`, and bumps `pypa/cibuildwheel` to v4.1.0. `requires-python`, the `build` glob (`cp314*`), the noxfile version gate, and the docs are updated to match.

cibuildwheel 4.0 also runs delvewheel on Windows by default. In `core-nanobind-shared` the shared library is installed next to the extension inside the wheel, so the repair command now passes `--ignore-existing` to stop delvewheel from searching PATH for it and failing.